### PR TITLE
Allow the root handler to use the propagate option

### DIFF
--- a/interrupt_handler/interrupt_handler.py
+++ b/interrupt_handler/interrupt_handler.py
@@ -4,13 +4,16 @@ import signal
 from .default_callback import default_callback
 
 class InterruptHandler(object):
+
+    DEFAULT_HANDLERS = {s: signal.getsignal(s) for s in signal.Signals}
+
     def __init__(self, callback=default_callback(), sig=signal.SIGINT, propagate=False):
         if not callable(callback):
             raise ValueError(f'callback parameter is not support {type(callback)}.')
         self.callback = callback
         self.sig = sig
         self.propagate = propagate
-        self.original_handler = None
+        self.original_handler = signal.getsignal(self.sig)
 
     @property
     def interrupted(self):
@@ -27,7 +30,6 @@ class InterruptHandler(object):
         if not self.original_handler:
             self._interrupted = False
             self.released = False
-            self.original_handler = signal.getsignal(self.sig)
             def handler(signum, frame):
                 if not self.callback():
                     self.release(True)
@@ -38,12 +40,11 @@ class InterruptHandler(object):
 
     def release(self, interrupted=False):
         if self.released:
-            if self.propagate:
+            if self.propagate and self.original_handler != self.DEFAULT_HANDLERS[self.sig]:
                 os.kill(os.getpid(), self.sig)
             return True
         if self.original_handler:
             signal.signal(self.sig, self.original_handler)
-            self.original_handler = None
         self.released = True
         if interrupted: raise KeyboardInterrupt
         return False


### PR DESCRIPTION
루트에 해당하는 `InterruptHandler`는 `original_handler`의 값이 기본 handler가 매핑되는 것을 이용해서,
`propagate` 옵션을 넣어서 현재 original handler가 새로 지정된 handler인지 default handler인지를 판단해서 exception을 발생시킬지 결정하도록 수정하였습니다.

이 과정에서 `original_handler` 변수를 non-nullable하게 변경하였는데 이 부분에 혹시 이슈가 있어서 알려주시면 다시 수정하겠습니다.